### PR TITLE
fix: remove trailing whitespace in anchor tags, wrap matched terms with links, and update GitHub Pages trigger branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,10 @@ name: Deploy MkDocs to GitHub Pages
 on:
   push:
     branches:
-      - develop-mkdocs  # Trigger this workflow on push to the develop branch
+      - main
   pull_request:
     branches:
-      - develop-mkdocs  # Also trigger on pull requests to the develop branch
+      - main
 
 jobs:
   deploy:

--- a/hooks.py
+++ b/hooks.py
@@ -33,7 +33,7 @@ def get_ontology_annotations(config, ontology_id, text):
         
         response.raise_for_status()
         response_data = response.json()
-        print(f"Response from {ontology_id} ontology: {response_data}")
+        # print(f"Response from {ontology_id} ontology: {response_data}")
 
         if 'matches' in response_data and isinstance(response_data['matches'], list):
             text_with_spans = wrap_terms_in_span(text, response_data['matches'])
@@ -49,7 +49,7 @@ def get_ontology_annotations(config, ontology_id, text):
 
 def wrap_terms_in_span(text, matches):
     
-    cleaner_matches = [{'matched_term': m['matched_term'], 'start': m['start'], 'end': m['end'], 'iri': m['iri']} for m in matches]
+    cleaner_matches = [{'term': m['token'],'matched_term': m['matched_term'], 'start': m['start'], 'end': m['end'], 'iri': m['iri']} for m in matches]
     sorted_matches = sorted(cleaner_matches, key=lambda m: (-len(m['matched_term']), -m['start']))
 
     modified_positions = set()
@@ -80,8 +80,8 @@ def wrap_terms_in_span(text, matches):
     
     for match in modifications:
         result += text[last_end:match['start']]
-        result += f"<a href={match['iri']} style='border-bottom: 1px dotted #666; text-decoration: none;'>{match['matched_term']}</a> "
-        last_end = match['end'] + 1
+        result += f"<a href={match['iri']} style='border-bottom: 1px dotted #666; text-decoration: none;'>{match['term']}</a>"
+        last_end = match['end']
     
     result += text[last_end:]
     


### PR DESCRIPTION
This pull request includes the following improvements:

Fixes annotation bugs like “wind turbine” being replaced with a different phrase due to replacing matched terms; now the original terms are kept and wrapped with links.

Fixes issues like “dataset” losing characters caused by trailing whitespace in anchor tags and an off-by-one error.

Updates the GitHub Pages workflow to trigger on the main branch instead of the develop branch, aligning deployment with the latest code.